### PR TITLE
FIX: envio do cep para o backend e mensagem de erro no NoRecords

### DIFF
--- a/src/pages/Charges/index.js
+++ b/src/pages/Charges/index.js
@@ -61,7 +61,7 @@ function Charges() {
                         </tr>
                     ))
 
-                    : <NoRecords element='clientes' pronoun='o' link='/clients/new' />
+                    : <NoRecords element='cobranças' pronoun='a' link='/charges/new' />
                 }
             </Table>
         </div>

--- a/src/pages/RegisterClient/index.js
+++ b/src/pages/RegisterClient/index.js
@@ -52,7 +52,7 @@ function RegisterClient() {
     const onSubmit = async (data) => {
         data.cpf = onlyNumbers(data.cpf);
         data.phone = onlyNumbers(data.phone);
-        const cepNumber = onlyNumbers(cep);
+        const zipcode = !cep ? null : onlyNumbers(cep);
 
         if(data.cpf.length < 11) {
             return setAlert({
@@ -86,7 +86,7 @@ function RegisterClient() {
                     district, 
                     street,
                     state, 
-                    zipcode: cepNumber
+                    zipcode
                 })
             });
 


### PR DESCRIPTION
Consertando o envio do cep para ser null quando não for informado e mudando o texto do NoRecords da listagem de cobranças quando não existe nenhuma. 